### PR TITLE
Fix crash on 0.6.9

### DIFF
--- a/ui/ui_menu_bar.py
+++ b/ui/ui_menu_bar.py
@@ -63,7 +63,7 @@ class UIMenuBar(UIElement):
         for menu_item_key, menu_item_data in self.menu_item_data.items():
             # create top level menu buttons
             default_font = self.ui_manager.get_theme().get_font_dictionary().get_default_font()
-            _, item_text_rect = default_font.render(menu_item_data['display_name'], (0, 0, 0))
+            item_text_rect = default_font.get_rect(menu_item_data['display_name'])
             UIButton(pygame.Rect(top_level_button_x,
                                  0,
                                  item_text_rect.width + 20,


### PR DESCRIPTION
I made it use get_rect for getting the item_text_rect, which fixes the crash on startup due to the new wrapper.
https://github.com/MyreMylar/pygame_gui/pull/418